### PR TITLE
Nil returned by inprocess plugins (AO-17663)

### DIFF
--- a/v2/runner/resources.go
+++ b/v2/runner/resources.go
@@ -34,7 +34,9 @@ func safeListenerAddr(ln net.Listener) net.TCPAddr {
 		return *ln.Addr().(*net.TCPAddr)
 	}
 
-	return net.TCPAddr{}
+	return net.TCPAddr{
+		IP: []byte("channel"),
+	}
 }
 
 func (r *resources) grpcListenerAddr() net.TCPAddr {


### PR DESCRIPTION
Nil returned by inprocess plugins (AO-17663)

* Set grpc ip address to "channel" value when plugin is inprocess

JIRA: (AO-17663)