### PR TITLE
Add support for OTel types of metrics (AO-20748)

### DIFF
--- a/v2/plugin/metrics.go
+++ b/v2/plugin/metrics.go
@@ -39,6 +39,9 @@ type Metric interface {
 
 	// Time, when measurement was taken
 	Timestamp() time.Time
+
+	// OTel type of metric
+	Type() MetricType
 }
 
 // Interface for setting custom metric metadata


### PR DESCRIPTION
* Added Type() function in Metric interface to obtain OTel type of metric

JIRA: (AO-20748)

https://swicloud.atlassian.net/browse/AO-20748

Summary of changes:
* Added Type() function to provide option for obtaining OTel type of metric in publishers