### PR TITLE
Show snap-related modules versions in --version message (AO-20539)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/solarwinds/snap-plugin-lib
 go 1.13
 
 require (
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/josephspurrier/goversioninfo v1.3.0
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/securego/gosec/v2 v2.8.1
 	github.com/sirupsen/logrus v1.8.0
 	github.com/smartystreets/goconvey v1.6.4

--- a/v2/runner/version.go
+++ b/v2/runner/version.go
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2020 SolarWinds Worldwide, LLC
+ Copyright (c) 2021 SolarWinds Worldwide, LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,8 +16,26 @@
 
 package runner
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
 
 func printVersion(name string, version string) {
 	fmt.Printf("%s version %s\n", name, version)
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok {
+		fmt.Printf("\tbuilt with:\n")
+
+		for _, dep := range buildInfo.Deps {
+			if strings.Contains(dep.Path, "snap-") {
+				path := strings.SplitAfter(dep.Path, "snap-")[1]
+				path = strings.Split(path, "/")[0]
+				fmt.Printf("\t%v (%v)\n", path, dep.Version)
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Sample output from collector-swi (swi version itself is "0.0.0" as it was built locally, not from CI/repo tag):

```
swi version 0.0.0
	built with:
	aoutils (v1.3.0)
	plugin-collector-docker (v48.0.3)
	plugin-collector-elasticsearch (v19.0.2)
	plugin-collector-haproxy (v15.0.2)
	plugin-collector-kubernetes (v26.0.2)
	plugin-lib (v1.0.0)
	plugin-lib (v2.4.1)
```