### PR TITLE
AO-20809 dotnet bindings with metric type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/solarwinds/snap-plugin-lib
 go 1.13
 
 require (
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-licenses v0.0.0-00010101000000-000000000000
 	github.com/josephspurrier/goversioninfo v1.4.0

--- a/v2/bindings/bindings.h
+++ b/v2/bindings/bindings.h
@@ -44,8 +44,8 @@ enum value_type_t {
 	TYPE_DOUBLE,
 	TYPE_BOOL,
 	TYPE_CSTRING,
-    TYPE_INT16,
-    TYPE_UINT16
+	TYPE_INT16,
+	TYPE_UINT16
 };
 
 typedef struct {
@@ -58,7 +58,7 @@ typedef struct {
 		double v_double;
 		int v_bool;
 		char * v_cstring;
-        short int v_int16;
+		short int v_int16;
 		unsigned short int v_uint16;
 	} value;
 	int vtype; // value_type_t;
@@ -187,12 +187,21 @@ static inline void set_time_with_ns_t(time_with_ns_t* time_ptr, int sec, int nse
 	time_ptr->nsec = nsec;
 }
 
+enum metric_type_t {
+	METRIC_TYPE_UNKNOWN,
+	METRIC_TYPE_GAUGE,
+	METRIC_TYPE_SUM,
+	METRIC_TYPE_SUMMARY,
+	METRIC_TYPE_HISTOGRAM
+};
+
 typedef struct {
 	map_t * tags_to_add;
 	map_t * tags_to_remove;
 	time_with_ns_t * timestamp;
 	char * description;
 	char * unit;
+	int metric_type;
 } modifiers_t;
 
 
@@ -366,56 +375,33 @@ typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
 extern "C" {
 #endif
 
-
-extern void dealloc_charp(char* p0);
-
-extern void dealloc_str_array(char** p0);
-
-extern void dealloc_error(error_t* p0);
-
-extern void dealloc_metric_array(metric_t** p0, GoInt p1);
-
-extern error_t* ctx_add_metric(char* p0, char* p1, value_t* p2, modifiers_t* p3);
-
-extern error_t* ctx_always_apply(char* p0, char* p1, modifiers_t* p2);
-
-extern void ctx_dismiss_all_modifiers(char* p0);
-
-extern GoInt ctx_should_process(char* p0, char* p1);
-
-extern char** ctx_requested_metrics(char* p0);
-
-extern GoInt ctx_count(char* p0);
-
-extern metric_t** ctx_list_all_metrics(char* p0);
-
-extern char* ctx_config_value(char* p0, char* p1);
-
-extern char** ctx_config_keys(char* p0);
-
-extern char* ctx_raw_config(char* p0);
-
-extern void ctx_add_warning(char* p0, char* p1);
-
-extern GoInt ctx_is_done(char* p0);
-
-extern void ctx_log(char* p0, int p1, char* p2, map_t* p3);
-
-extern void define_metric(char* p0, char* p1, GoInt p2, char* p3);
-
-extern void define_group(char* p0, char* p1);
-
-extern error_t* define_example_config(char* p0);
-
-extern void define_tasks_per_instance_limit(GoInt p0);
-
-extern void define_instances_limit(GoInt p0);
-
-extern void start_collector(callback_t* p0, callback_t* p1, callback_t* p2, define_callback_t* p3, char* p4, char* p5);
+extern __declspec(dllexport) void dealloc_charp(char* p);
+extern __declspec(dllexport) void dealloc_str_array(char** p);
+extern __declspec(dllexport) void dealloc_error(error_t* p);
+extern __declspec(dllexport) void dealloc_metric_array(metric_t** p, GoInt size);
+extern __declspec(dllexport) error_t* ctx_add_metric(char* ctxID, char* ns, value_t* v, modifiers_t* modifiers);
+extern __declspec(dllexport) error_t* ctx_always_apply(char* ctxID, char* ns, modifiers_t* modifiers);
+extern __declspec(dllexport) void ctx_dismiss_all_modifiers(char* ctxID);
+extern __declspec(dllexport) GoInt ctx_should_process(char* ctxID, char* ns);
+extern __declspec(dllexport) char** ctx_requested_metrics(char* ctxID);
+extern __declspec(dllexport) GoInt ctx_count(char* ctxID);
+extern __declspec(dllexport) metric_t** ctx_list_all_metrics(char* ctxID);
+extern __declspec(dllexport) char* ctx_config_value(char* ctxID, char* key);
+extern __declspec(dllexport) char** ctx_config_keys(char* ctxID);
+extern __declspec(dllexport) char* ctx_raw_config(char* ctxID);
+extern __declspec(dllexport) void ctx_add_warning(char* ctxID, char* message);
+extern __declspec(dllexport) GoInt ctx_is_done(char* ctxID);
+extern __declspec(dllexport) void ctx_log(char* ctxID, int level, char* message, map_t* fields);
+extern __declspec(dllexport) void define_metric(char* namespace, char* unit, GoInt isDefault, char* description);
+extern __declspec(dllexport) void define_group(char* name, char* description);
+extern __declspec(dllexport) error_t* define_example_config(char* cfg);
+extern __declspec(dllexport) void define_tasks_per_instance_limit(GoInt limit);
+extern __declspec(dllexport) void define_instances_limit(GoInt limit);
+extern __declspec(dllexport) void start_collector(callback_t* collectCallback, callback_t* loadCallback, callback_t* unloadCallback, define_callback_t* defineCallback, char* name, char* version);
+extern __declspec(dllexport) void start_streaming_collector(callback_t* collectCallback, callback_t* loadCallback, callback_t* unloadCallback, define_callback_t* defineCallback, char* name, char* version);
 
 /***************************************************************************/
-
-extern void start_publisher(callback_t* p0, callback_t* p1, callback_t* p2, define_callback_t* p3, char* p4, char* p5);
+extern __declspec(dllexport) void start_publisher(callback_t* publishCallback, callback_t* loadCallback, callback_t* unloadCallback, define_callback_t* defineCallback, char* name, char* version);
 
 #ifdef __cplusplus
 }

--- a/v2/bindings/csharp/SnapPluginLibCs/CollectorExample/CollectorExample.cs
+++ b/v2/bindings/csharp/SnapPluginLibCs/CollectorExample/CollectorExample.cs
@@ -81,8 +81,15 @@ namespace CollectorExample
                 Modifiers.Description("new custom description")
             );
 
-            ctx.AddMetric("/example/group1/metric2", 20);
-            ctx.AddMetric("/example/group1/metric3", 30);
+            ctx.AddMetric("/example/group1/metric2", 20,
+                Modifiers.Unit("s"),
+                Modifiers.GaugeType()
+            );
+
+            ctx.AddMetric("/example/group1/metric3", 30,
+                Modifiers.Unit("min"),
+                Modifiers.SumType()
+            );
 
             if (ctx.ShouldProcess("/example/group2/metric4"))
             {

--- a/v2/bindings/csharp/SnapPluginLibCs/CollectorExample/CollectorExample.csproj
+++ b/v2/bindings/csharp/SnapPluginLibCs/CollectorExample/CollectorExample.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/Modifiers.cs
+++ b/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/Modifiers.cs
@@ -141,4 +141,19 @@ namespace SnapPluginLib
 
         private readonly string _unit;
     }
+
+    internal class MetricType : Modifier
+    {
+        public MetricType(NativeMetricType type)
+        {
+            _type = type;
+        }
+
+        internal override void Apply(NativeModifiers nModifier)
+        {
+            nModifier.metric_type = (int)_type;
+        }
+
+        private readonly NativeMetricType _type;
+    }
 }

--- a/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/Modifiers.cs
+++ b/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/Modifiers.cs
@@ -59,6 +59,26 @@ namespace SnapPluginLib
         {
             return new MetricUnit(unit);
         }
+
+        public static Modifier GaugeType()
+        {
+            return new MetricType(NativeMetricType.Gauge);
+        }
+
+        public static Modifier SumType()
+        {
+            return new MetricType(NativeMetricType.Sum);
+        }
+
+        public static Modifier SummaryType()
+        {
+            return new MetricType(NativeMetricType.Summary);
+        }
+
+        public static Modifier HistogramType()
+        {
+            return new MetricType(NativeMetricType.Histogram);
+        }
     }
 
     internal class MetricTags : Modifier
@@ -93,7 +113,7 @@ namespace SnapPluginLib
 
     internal class MetricTimestamp : Modifier
     {
-        const int MilliToNanoFactor = (int) 1e6;
+        const int MilliToNanoFactor = (int)1e6;
 
         public MetricTimestamp(DateTime timestamp)
         {

--- a/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/NativeTypes.cs
+++ b/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/NativeTypes.cs
@@ -91,7 +91,7 @@ namespace SnapPluginLib
     internal enum NativeMetricType {
         Unknown,
         Gauge,
-        Sym,
+        Sum,
         Summary,
         Histogram,
     }

--- a/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/NativeTypes.cs
+++ b/v2/bindings/csharp/SnapPluginLibCs/SnapPluginLib/NativeTypes.cs
@@ -42,6 +42,8 @@ namespace SnapPluginLib
         
         [MarshalAs(UnmanagedType.LPStr)] public string description;
         [MarshalAs(UnmanagedType.LPStr)] public string unit;
+
+        public int metric_type;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -84,5 +86,13 @@ namespace SnapPluginLib
     internal class NativeError
     {
         public string errorMessage;
+    }
+
+    internal enum NativeMetricType {
+        Unknown,
+        Gauge,
+        Sym,
+        Summary,
+        Histogram,
     }
 }

--- a/v2/bindings/csharp/SnapPluginLibCs/StreamingCollectorExample/StreamingCollectorExample.csproj
+++ b/v2/bindings/csharp/SnapPluginLibCs/StreamingCollectorExample/StreamingCollectorExample.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/v2/bindings/main.go
+++ b/v2/bindings/main.go
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021 SolarWinds Worldwide, LLC
+ Copyright (c) 2022 SolarWinds Worldwide, LLC
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.

--- a/v2/snap-mock/main.go
+++ b/v2/snap-mock/main.go
@@ -528,7 +528,7 @@ func grpcMetricToString(metric *pluginrpc.Metric) string {
 		nsStr = append(nsStr, ns.Value)
 	}
 
-	return fmt.Sprintf("%s %v [%v]", strings.Join(nsStr, "."), metric.Value, metric.Tags)
+	return fmt.Sprintf("%s value: %v unit: %v type: %v tags: [%v]", strings.Join(nsStr, "."), metric.Value, metric.Unit, metric.Type, metric.Tags)
 }
 
 func grpcWarningToString(warning *pluginrpc.Warning) string {

--- a/v2/tutorial/02-testing/README.md
+++ b/v2/tutorial/02-testing/README.md
@@ -136,36 +136,41 @@ Now, in other console, you should locate snap-mock, compile it and execute:
 ```bash
 cd $GOPATH/src/github.com/solarwinds/snap-plugin-lib/v2/snap-mock
 go build
-./snap-mock -plugin-port=50123 -max-collect-requests=3 -collect-interval=5s -send-kill=1
+./snap-mock -collector-port=50123 -max-collect-requests=3 -collect-interval=5s -send-kill=1
 ```
 
-> Make sure that `-grpc-port` (provided for plugin) and `-plugin-port` (provided for snap-mock) are the same.
+> Make sure that `-grpc-port` (provided for plugin) and `-collector-port` (provided for snap-mock) are the same.
 
 > `-send-kill` flag causes both, plugin and snap-mock, to complete with an execute.
 
 Output of snap-mock:
 ```
+Received 5 metric(s)
+ example.date.day value: v_int64:25  unit:  type: UNKNOWN tags: [map[]]
+ example.date.month value: v_int64:1  unit:  type: UNKNOWN tags: [map[]]
+ example.time.hour value: v_int64:15  unit:  type: UNKNOWN tags: [map[]]
+ example.time.minute value: v_int64:0  unit:  type: UNKNOWN tags: [map[]]
+ example.time.second value: v_int64:8  unit:  type: UNKNOWN tags: [map[]]
+
+Received 0 warning(s)
 
 Received 5 metric(s)
- example.date.day v_int64:3  [map[]]
- example.date.month v_int64:9  [map[]]
- example.time.hour v_int64:16  [map[]]
- example.time.minute v_int64:39  [map[]]
- example.time.second v_int64:30  [map[]]
+ example.date.day value: v_int64:25  unit:  type: UNKNOWN tags: [map[]]
+ example.date.month value: v_int64:1  unit:  type: UNKNOWN tags: [map[]]
+ example.time.hour value: v_int64:15  unit:  type: UNKNOWN tags: [map[]]
+ example.time.minute value: v_int64:0  unit:  type: UNKNOWN tags: [map[]]
+ example.time.second value: v_int64:13  unit:  type: UNKNOWN tags: [map[]]
+
+Received 0 warning(s)
 
 Received 5 metric(s)
- example.date.day v_int64:3  [map[]]
- example.date.month v_int64:9  [map[]]
- example.time.hour v_int64:16  [map[]]
- example.time.minute v_int64:39  [map[]]
- example.time.second v_int64:35  [map[]]
+ example.date.day value: v_int64:25  unit:  type: UNKNOWN tags: [map[]]
+ example.date.month value: v_int64:1  unit:  type: UNKNOWN tags: [map[]]
+ example.time.hour value: v_int64:15  unit:  type: UNKNOWN tags: [map[]]
+ example.time.minute value: v_int64:0  unit:  type: UNKNOWN tags: [map[]]
+ example.time.second value: v_int64:18  unit:  type: UNKNOWN tags: [map[]]
 
-Received 5 metric(s)
- example.date.day v_int64:3  [map[]]
- example.date.month v_int64:9  [map[]]
- example.time.hour v_int64:16  [map[]]
- example.time.minute v_int64:39  [map[]]
- example.time.second v_int64:40  [map[]]
+Received 0 warning(s)
 ```
 
 Output of plugin:

--- a/v2/tutorial/04-metrics/README.md
+++ b/v2/tutorial/04-metrics/README.md
@@ -162,6 +162,18 @@ with additional modifiers:
 		plugin.MetricUnit("HH"))
 ```
 
+Another metric metadata which can be set during `AddMetric()` call is its `Type`:
+
+```go
+	ctx.AddMetric("/example/time/minute", minute,
+		plugin.MetricUnit("min"),
+		plugin.MetricTypeGauge())
+
+	ctx.AddMetric("/example/time/unix_time", minute,
+		plugin.MetricUnit("s"),
+		plugin.MetricTypeSum())
+```
+
 ----
 
 * [Table of contents](/v2/README.md)

--- a/v2/tutorial/05-tools/README.md
+++ b/v2/tutorial/05-tools/README.md
@@ -89,8 +89,8 @@ To enable this feature simply run plugin with the following arguments:
 
 To simulate two independent tasks, call snap-mock twice:
 ```bash
-./snap-mock -plugin-port=50123 -max-collect-requests=12 -collect-interval=5s -task-id=1 &
-./snap-mock -plugin-port=50123 -max-collect-requests=12 -collect-interval=5s -task-id=2 &
+./snap-mock -collector-port=50123 -max-collect-requests=12 -collect-interval=5s -task-id=1 &
+./snap-mock -collector-port=50123 -max-collect-requests=12 -collect-interval=5s -task-id=2 &
 ```
 
 To see output of stats server, open a browser on address http://127.0.0.1:8080/stats.


### PR DESCRIPTION
https://swicloud.atlassian.net/browse/AO-20809

Summary of changes:
* Added `metric_type` field and enum to cgo modifier type
* Added matching field and enum to corresponding C# code
* Added usage of `Unit` and `Type` modifiers in the example

Notes:
* Changed properties of example projects so that executable images are created