### PR TITLE
CRI large tests don't see containerd internal metrics (AO-20638)

### DIFF
--- a/v2/internal/util/metrictree/parser.go
+++ b/v2/internal/util/metrictree/parser.go
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2020 SolarWinds Worldwide, LLC
+ Copyright (c) 2022 SolarWinds Worldwide, LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/v2/internal/util/metrictree/parser.go
+++ b/v2/internal/util/metrictree/parser.go
@@ -205,6 +205,7 @@ func isValidIdentifier(s string) bool {
 		case el == '-' || el == '_':
 		case el == '.':
 		case el == '+':
+		case el == '/':
 		default:
 			return false
 		}


### PR DESCRIPTION
* Extended metric namespace validator about new character

JIRA: (AO-20638)